### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,20 +157,19 @@ func getWikiMarkup(title string) (string, error) {
 	content := main["content"].(string)
 
 	return content, nil
-        }
-        
+}
 
 func ProcessMainDraw(text string) {
-        scanner := bufio.NewScanner(strings.NewReader(text))
-        for scanner.Scan() {
-                line := scanner.Text()
-                if strings.HasPrefix(line, "==") {
-                        fmt.Println(line)
-                }
-        }
-if err := scanner.Err(); err != nil {
-                fmt.Printf("Ошибка: %v\n", err)
-        }
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "==") {
+			fmt.Println(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("Ошибка: %v\n", err)
+	}
 }
 
 func main() {
@@ -179,6 +178,6 @@ func main() {
 		fmt.Printf("Ошибка: %v\n", err)
 		return
 	}
- ProcessMainDraw(markup)
+	ProcessMainDraw(markup)
 	fmt.Println(os.Args)
 }

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func ProcessMainDraw(text string) {
         scanner := bufio.NewScanner(strings.NewReader(text))
         for scanner.Scan() {
                 line := scanner.Text()
-                if strings.HasPrefix(line, "=") {
+                if strings.HasPrefix(line, "==") {
                         fmt.Println(line)
                 }
         }

--- a/main.go
+++ b/main.go
@@ -158,9 +158,7 @@ func getWikiMarkup(title string) (string, error) {
 
 	return content, nil
         }
-        if err := scanner.Err(); err != nil {
-                // handle I/O or tokenization error
-        }
+        
 
 func ProcessMainDraw(text string) {
         scanner := bufio.NewScanner(strings.NewReader(text))
@@ -169,6 +167,9 @@ func ProcessMainDraw(text string) {
                 if strings.HasPrefix(line, "==") {
                         fmt.Println(line)
                 }
+        }
+if err := scanner.Err(); err != nil {
+                fmt.Printf("Ошибка: %v\n", err)
         }
 }
 

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func getWikiMarkup(title string) (string, error) {
 }
 
 func ProcessMainDraw(text string) {
-        scanner := bufio.NewScanner(text)
+        scanner := bufio.NewScanner(strings.NewReader(text))
         for scanner.Scan() {
                 line := scanner.Text()
                 if strings.HasPrefix(line, "=") {

--- a/main.go
+++ b/main.go
@@ -157,7 +157,10 @@ func getWikiMarkup(title string) (string, error) {
 	content := main["content"].(string)
 
 	return content, nil
-}
+        }
+        if err := scanner.Err(); err != nil {
+                // handle I/O or tokenization error
+        }
 
 func ProcessMainDraw(text string) {
         scanner := bufio.NewScanner(strings.NewReader(text))

--- a/main.go
+++ b/main.go
@@ -159,12 +159,22 @@ func getWikiMarkup(title string) (string, error) {
 	return content, nil
 }
 
+func ProcessMainDraw(text string) {
+        scanner := bufio.NewScanner(text)
+        for scanner.Scan() {
+                line := scanner.Text()
+                if strings.HasPrefix(line, "=") {
+                        fmt.Println(line)
+                }
+        }
+}
+
 func main() {
 	markup, err := getWikiMarkup("2025 World Snooker Championship")
 	if err != nil {
 		fmt.Printf("Ошибка: %v\n", err)
 		return
 	}
-	fmt.Println(markup)
+ ProcessMainDraw(markup)
 	fmt.Println(os.Args)
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a function to scan and print only the main draw lines from the wiki markup and update main to use it instead of printing the raw markup.

Enhancements:
- Introduce ProcessMainDraw to scan input text and print lines starting with '='
- Update main to invoke ProcessMainDraw on fetched markup instead of directly printing it