### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,47 +160,46 @@ func getWikiMarkup(title string) (string, error) {
 }
 
 func ExtractSection(wikiText, sectionName string) string {
-        var sectionContent []string
-    inSection := false
-    sectionLevel := 0
-    sectionName = strings.TrimSpace(strings.ToLower(sectionName))
+	var sectionContent []string
+	inSection := false
+	sectionLevel := 0
+	sectionName = strings.TrimSpace(strings.ToLower(sectionName))
 
-        scanner := bufio.NewScanner(strings.NewReader(wikiText))
-        for scanner.Scan() {
-                line := scanner.Text()
-                trimmedLine := strings.TrimSpace(line)
-                if strings.HasPrefix(trimmedLine, "=") && strings.HasSuffix(trimmedLine, "=") {
-            headerText := strings.Trim(trimmedLine, "=")
-            headerText = strings.TrimSpace(headerText)
-            levelCount := len(trimmedLine) - len(strings.TrimLeft(trimmedLine, "="))
+	scanner := bufio.NewScanner(strings.NewReader(wikiText))
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "=") && strings.HasSuffix(trimmedLine, "=") {
+			headerText := strings.Trim(trimmedLine, "=")
+			headerText = strings.TrimSpace(headerText)
+			levelCount := len(trimmedLine) - len(strings.TrimLeft(trimmedLine, "="))
 
-            if inSection && levelCount <= sectionLevel {
-                break
-            }
+			if inSection && levelCount <= sectionLevel {
+				break
+			}
 
-            if strings.ToLower(headerText) == sectionName {
-                inSection = true
-                sectionLevel = levelCount
-                continue
-            }
-        }
+			if strings.ToLower(headerText) == sectionName {
+				inSection = true
+				sectionLevel = levelCount
+				continue
+			}
+		}
 
-        if inSection {
-            sectionContent = append(sectionContent, line)
-        }
-        }
-return strings.TrimSpace(strings.Join(sectionContent, "\n"))
+		if inSection {
+			sectionContent = append(sectionContent, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(sectionContent, "\n"))
 }
 
 func ProcessMainDraw(wikiText string) {
-        content := ExtractSection(wikiText, "Main draw")
-        scanner := bufio.NewScanner(strings.NewReader(text))
-        for scanner.Scan() {
-                line := scanner.Text()
-                        fmt.Println(line)
-        }
+	content := ExtractSection(wikiText, "Main draw")
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := scanner.Text()
+		fmt.Println(line)
+	}
 }
-
 
 func main() {
 	markup, err := getWikiMarkup("2025 World Snooker Championship")

--- a/main.go
+++ b/main.go
@@ -159,18 +159,48 @@ func getWikiMarkup(title string) (string, error) {
 	return content, nil
 }
 
-func ProcessMainDraw(text string) {
-	scanner := bufio.NewScanner(strings.NewReader(text))
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "==") {
-			fmt.Println(line)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		fmt.Printf("Ошибка: %v\n", err)
-	}
+func ExtractSection(wikiText, sectionName string) string {
+        var sectionContent []string
+    inSection := false
+    sectionLevel := 0
+    sectionName = strings.TrimSpace(strings.ToLower(sectionName))
+
+        scanner := bufio.NewScanner(strings.NewReader(wikiText))
+        for scanner.Scan() {
+                line := scanner.Text()
+                trimmedLine := strings.TrimSpace(line)
+                if strings.HasPrefix(trimmedLine, "=") && strings.HasSuffix(trimmedLine, "=") {
+            headerText := strings.Trim(trimmedLine, "=")
+            headerText = strings.TrimSpace(headerText)
+            levelCount := len(trimmedLine) - len(strings.TrimLeft(trimmedLine, "="))
+
+            if inSection && levelCount <= sectionLevel {
+                break
+            }
+
+            if strings.ToLower(headerText) == sectionName {
+                inSection = true
+                sectionLevel = levelCount
+                continue
+            }
+        }
+
+        if inSection {
+            sectionContent = append(sectionContent, line)
+        }
+        }
+return strings.TrimSpace(strings.Join(sectionContent, "\n"))
 }
+
+func ProcessMainDraw(wikiText string) {
+        content := ExtractSection(wikiText, "Main draw")
+        scanner := bufio.NewScanner(strings.NewReader(text))
+        for scanner.Scan() {
+                line := scanner.Text()
+                        fmt.Println(line)
+        }
+}
+
 
 func main() {
 	markup, err := getWikiMarkup("2025 World Snooker Championship")

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func ExtractSection(wikiText, sectionName string) string {
 
 func ProcessMainDraw(wikiText string) {
 	content := ExtractSection(wikiText, "Main draw")
-	scanner := bufio.NewScanner(strings.NewReader(text))
+	scanner := bufio.NewScanner(strings.NewReader(content))
 	for scanner.Scan() {
 		line := scanner.Text()
 		fmt.Println(line)


### PR DESCRIPTION
## Summary by Sourcery

Add a utility to extract specific sections from wiki markup and update the main drawing processor to use this utility for handling only the “Main draw” section

Enhancements:
- Introduce ExtractSection to isolate a named wiki section based on header levels
- Refactor ProcessMainDraw to leverage ExtractSection and target only the "Main draw" section